### PR TITLE
Use Buffer.byteLength instead of String.prototype.length to set

### DIFF
--- a/src/app/consumer/postback.js
+++ b/src/app/consumer/postback.js
@@ -38,7 +38,7 @@ module.exports = function(callbackUrl, queryParams, rawData) {
             path: path,
             method: 'POST',
             headers: {
-                'Content-Length': rawData.length,
+                'Content-Length': Buffer.byteLength(rawData),
                 'Content-Type': 'text/html'
             }
         },


### PR DESCRIPTION
data length because the latter does not measure correctly for
multi byte characters.
